### PR TITLE
Enabling device configuration via device manager API

### DIFF
--- a/DeviceManager/BackendHandler.py
+++ b/DeviceManager/BackendHandler.py
@@ -121,19 +121,24 @@ class KafkaHandler(BackendHandler):
         """
             Publishes event to kafka broker, notifying device creation
         """
-        sendNotification(DeviceEvent.CREATED, device, meta)
+        sendNotification(DeviceEvent.CREATE, device, meta)
 
     def remove(self, device_id, meta):
         """
             Publishes event to kafka broker, notifying device removal
         """
-        sendNotification(DeviceEvent.REMOVED, device, meta)
+        sendNotification(DeviceEvent.REMOVE, device, meta)
 
     def update(self, device, meta):
         """
             Publishes event to kafka broker, notifying device update
         """
         sendNotification(DeviceEvent.UPDATE, device, meta)
+    def configure(self, device, meta):
+        """
+            Publishes event to kafka broker, notifying device configuration
+        """
+        sendNotification(DeviceEvent.CONFIGURE, device, meta)
 
 # deprecated
 class IotaHandler(BackendHandler):

--- a/DeviceManager/DeviceManager.py
+++ b/DeviceManager/DeviceManager.py
@@ -230,15 +230,13 @@ def update_device(deviceid):
 @device.route('/device/<deviceid>/attrs', methods=['PUT'])
 def configure_device(deviceid):
     try:
-        LOGGER.info("Finding tenant context.")
         tenant = init_tenant_context(request, db)
-        LOGGER.info("Tenant is: " + tenant)
-        old_device = assert_device_exists(deviceid)
-
-        LOGGER.info("Parsing payload...")
+        # In fact, the actual device is not needed. We must be sure that it exists.
+        assert_device_exists(deviceid)
         json_payload = json.loads(request.data)
-        LOGGER.info("... payload was parsed")
         kafka_handler = KafkaHandler()
+        # Remove topic metadata from JSON to be sent to the device
+        # Should this be moved to a HTTP header?
         topic = json_payload["topic"]
         del json_payload["topic"]
 

--- a/DeviceManager/DeviceManager.py
+++ b/DeviceManager/DeviceManager.py
@@ -242,6 +242,7 @@ def configure_device(deviceid):
 
         kafka_handler.configure(json_payload, meta = { "service" : tenant, "id" : deviceid, "topic": topic})
 
+        result = {'message': 'configuration sent'}
         return make_response(result, 200)
 
     except HTTPRequestError as e:

--- a/DeviceManager/KafkaNotifier.py
+++ b/DeviceManager/KafkaNotifier.py
@@ -8,9 +8,10 @@ LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.DEBUG)
 
 class DeviceEvent:
-    CREATED = "created"
-    UPDATED = "updated"
-    REMOVED = "removed"
+    CREATE = "create"
+    UPDATE = "update"
+    REMOVE = "remove"
+    CONFIGURE = "configure"
 
 class NotificationMessage:
     event = ""


### PR DESCRIPTION
This PR implements device configuration API. 

As this is the first implementation, the approach could be further explored to include more advanced things, such as using a generic model to apply configurations (just like the translators added as meta-information in the device model), configuration failure notifications (if needed), and so on.


This implements in part dojot/dojot#133 along with dojot/iotagent-json#12