### PR TITLE
Adding a how to use page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ gunicorn device-manager.app:app
 ```
 
 Keep in mind that running a standalone instance of DeviceManager misses a lot of security checks (such as user identity checks, proper multi-tenancy validations, and so on). In particular, every request sent to DeviceManager needs an access token, which should be retrived from [auth](https://github.com/dojot/auth) component. In the examples listed in this README, you can generate one by yourself (for now, DeviceManager doesn't check if the token is actually valid for that user - they are verified by auth and the API gateway) but this method might not work in the future as more strict token checks are implemented in DeviceManager.
+
+## How to use
+
+There are a few examples on how to use DeviceManager in [this page](./docs/using-device-manager.md).

--- a/docs/apiary.apib
+++ b/docs/apiary.apib
@@ -11,6 +11,8 @@ In fact, templates can represent not only "device models", but it can also abstr
 
 In order to create a device, a user selects which templates are going to compose this new device. All their attributes are merged together and associated to it - they are tightly linked to the original template so that any template update will reflect all associated devices.
 
+This document describes the APIs using DeviceManager as a standalone process. If used with other dojot's components, the endpoints might be changed a bit. Check [dojot's documentation](http://dojotdocs.readthedocs.io/) to check all of them.
+
 # Group Templates
 Before describing the device APIs, we must detail the template endpoints. As said before, templates are a way to describe the "device model", or, more abstractly, a "device class". These templates contains all the attributes that will be applied to the device. Always remember that they can (and eventually will) be merged into one to create a single device - they must not have attributes with the same name. If this is inevitable, a tag could be added to the attribute name and, while creating the device, translation instructions could be created in order to map each attribute from the incoming message to the appropriate device attribute.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -34,7 +34,7 @@ The information model used for both "real" and virtual devices is as following:
 
 ## Template
 
-All devices are created based on a *template*, which can be thought as a model of a device. As "model" we could think of part numbers or product models - one *prototype* from which devices are created. Templates in dojot have one label (any alphanumeric sequece), a list of attributes which will hold all the device emitted information, and optionally a few special attributes which will indicate how the device communicates, including transmission methods (protocol, ports, etc.) and message formats.
+All devices are created based on a *template*, which can be thought as a model of a device. As "model" we could think of part numbers or product models - one *prototype* from which devices are created. Templates in dojot have one label (any alphanumeric sequence), a list of attributes which will hold all the device emitted information, and optionally a few special attributes which will indicate how the device communicates, including transmission methods (protocol, ports, etc.) and message formats.
 
 In fact, templates can represent not only "device models", but it can also abstract a "class of devices". For instance, we could have one template to represent all themometers that will be used in dojot. This template would have only one attribute called, let's say, "temperature". While creating the device, the user would select its "physical template", let's say *TexasInstr882*, and the 'thermometer' template. The user would have also to add translation instructions in order to map the temperature reading that will be sent from the device to a "temperature" attribute. 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,4 +37,4 @@ Keep in mind that running a standalone instance of DeviceManager misses a lot of
 
 There are a few concepts that must be understood to properly use DeviceManager. Visit [this page](concepts.md) to check them out.
 
-This component listens to HTTP requests at port 5000 - all its endpoints are documented [here](apis.html). __IMPORTANT: If you are using all dojot's components (for instance, using a deploy based on [docker-compose](https://github.com/dojot/docker-compose)), it is recommended to visit [dojot's documentation](http://dojotdocs.readthedocs.io/en/latest/user_guide.html) to check the endpoints for all services (including DeviceManager's)__
+This component listens to HTTP requests at port 5000 - all its endpoints are documented [here](apis.html). __IMPORTANT: If you are using all dojot's components (for instance, using a deploy based on [docker-compose](https://github.com/dojot/docker-compose)), it is recommended to visit [dojot's documentation](http://dojotdocs.readthedocs.io/en/latest/apis.html) to check the endpoints for all services (including DeviceManager's)__

--- a/docs/using-device-manager.md
+++ b/docs/using-device-manager.md
@@ -1,0 +1,462 @@
+# Using DeviceManager
+
+Using DeviceManager is indeed simple: create a template with attributes and then create devices using that template. That's it.
+This page will show how to do that.
+
+All examples in this page consider that all dojot's components are up and running (check [the documentation](http://dojotdocs.readthedocs.io/) for how to do that). All request will include a ```${JWT}``` variable - this was retrieved from [auth](https://github.com/dojot/auth) component.
+
+## Creating templates and devices
+
+Right off the bat, let's retrieve a token from `auth`:
+
+```bash
+curl -X POST http://localhost:8000/auth \
+-H 'Content-Type:application/json' \
+-d '{"username": "admin", "passwd" : "admin"}'
+```
+
+```json
+{
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIU..."
+}
+```
+
+This token will be stored in ```bash ${JWT}``` bash variable, referenced in all requests.
+
+*IMPORTANT*: Every request made with this token will be valid only for the user associated with this token. For instance, listing created devices will return only those devices which were created by this user.
+
+-------------
+
+A template is, simply put, a model from which devices can be created. They can be merged to build a single device (or a set of devices). It is created by sending a HTTP request to DeviceManager:
+
+```bash
+curl -X POST http://localhost:8000/template \
+-H "Authorization: Bearer ${JWT}" \
+-H 'Content-Type:application/json' \
+-d ' {
+  "label": "SuperTemplate",
+  "attrs": [
+    {
+      "label": "temperature",
+      "type": "dynamic",
+      "value_type": "float"
+    },
+    {
+      "label": "pressure",
+      "type": "dynamic",
+      "value_type": "float"
+    },
+    {
+      "label": "model",
+      "type": "static",
+      "value_type" : "string",
+      "static_value" : "SuperTemplate Rev01"
+    }
+  ]
+}'
+```
+
+Supported value types are: "float", "string", "geo" (for georeference data)s, "integer". Supported value types are: "dynamic" and "static" (static attribute values defined here will be copied to all associated devices)
+
+The answer is:
+
+```json
+{
+  "result": "ok",
+  "template": {
+    "created": "2018-01-05T15:41:54.803052+00:00",
+    "attrs": [
+      {
+        "template_id": "1",
+        "created": "2018-01-05T15:41:54.840116+00:00",
+        "label": "temperature",
+        "value_type": "float",
+        "type": "dynamic",
+        "id": 1
+      },
+      {
+        "template_id": "1",
+        "created": "2018-01-05T15:41:54.882169+00:00",
+        "label": "pressure",
+        "value_type": "float",
+        "type": "dynamic",
+        "id": 2
+      },
+      {
+        "static_value": "SuperTemplate Rev01",
+        "created": "2018-01-05T15:41:54.883507+00:00",
+        "label": "model",
+        "value_type": "string",
+        "type": "static",
+        "id": 3,
+        "template_id": "1"
+      }
+    ],
+    "id": 1,
+    "label": "SuperTemplate"
+  }
+}
+```
+
+Let's create one more template, so that we can see what happens when two templates are merged.
+
+```bash
+curl -X POST http://localhost:8000/template \
+-H "Authorization: Bearer ${JWT}" \
+-H 'Content-Type:application/json' \
+-d ' {
+  "label": "ExtraTemplate",
+  "attrs": [
+    {
+      "label": "gps",
+      "type": "dynamic",
+      "value_type": "geo"
+    }
+  ]
+}'
+
+```
+
+Which results in:
+
+```json
+{
+  "result": "ok",
+  "template": {
+    "created": "2018-01-05T15:47:02.993965+00:00",
+    "attrs": [
+      {
+        "template_id": "2",
+        "created": "2018-01-05T15:47:02.995541+00:00",
+        "label": "gps",
+        "value_type": "geo",
+        "type": "dynamic",
+        "id": 4
+      }
+    ],
+    "id": 2,
+    "label": "ExtraTemplate"
+  }
+}
+```
+
+Let's check all templates we've created so far.
+
+```bash
+curl -X GET http://localhost:8000/template -H "Authorization: Bearer ${JWT}"
+```
+
+```json
+{
+  "templates": [
+    {
+      "created": "2018-01-05T15:41:54.803052+00:00",
+      "attrs": [
+        {
+          "template_id": "1",
+          "created": "2018-01-05T15:41:54.840116+00:00",
+          "label": "temperature",
+          "value_type": "float",
+          "type": "dynamic",
+          "id": 1
+        },
+        {
+          "template_id": "1",
+          "created": "2018-01-05T15:41:54.882169+00:00",
+          "label": "pressure",
+          "value_type": "float",
+          "type": "dynamic",
+          "id": 2
+        },
+        {
+          "static_value": "SuperTemplate Rev01",
+          "created": "2018-01-05T15:41:54.883507+00:00",
+          "label": "model",
+          "value_type": "string",
+          "type": "static",
+          "id": 3,
+          "template_id": "1"
+        }
+      ],
+      "id": 1,
+      "label": "SuperTemplate"
+    },
+    {
+      "created": "2018-01-05T15:47:02.993965+00:00",
+      "attrs": [
+        {
+          "template_id": "2",
+          "created": "2018-01-05T15:47:02.995541+00:00",
+          "label": "gps",
+          "value_type": "geo",
+          "type": "dynamic",
+          "id": 4
+        }
+      ],
+      "id": 2,
+      "label": "ExtraTemplate"
+    }
+  ],
+  "pagination": {
+    "has_next": false,
+    "next_page": null,
+    "total": 1,
+    "page": 1
+  }
+}
+```
+
+Now devices can be created using these two templates. Such request would be:
+
+```bash
+curl -X POST http://localhost:8000/device \
+-H "Authorization: Bearer ${JWT}" \
+-H 'Content-Type:application/json' \
+-d ' {
+  "templates": [
+    "1",
+    "2"
+  ],
+  "label": "device"
+}'
+```
+
+The result is:
+
+```json
+{
+  "device": {
+    "templates": [
+      1,
+      2
+    ],
+    "created": "2018-01-05T17:33:31.605748+00:00",
+    "attrs": {
+      "1": [
+        {
+          "template_id": "1",
+          "created": "2018-01-05T15:41:54.840116+00:00",
+          "label": "temperature",
+          "value_type": "float",
+          "type": "dynamic",
+          "id": 1
+        },
+        {
+          "template_id": "1",
+          "created": "2018-01-05T15:41:54.882169+00:00",
+          "label": "pressure",
+          "value_type": "float",
+          "type": "dynamic",
+          "id": 2
+        },
+        {
+          "static_value": "SuperTemplate Rev01",
+          "created": "2018-01-05T15:41:54.883507+00:00",
+          "label": "model",
+          "value_type": "string",
+          "type": "static",
+          "id": 3,
+          "template_id": "1"
+        }
+      ],
+      "2": [
+        {
+          "template_id": "2",
+          "created": "2018-01-05T15:47:02.995541+00:00",
+          "label": "gps",
+          "value_type": "geo",
+          "type": "dynamic",
+          "id": 4
+        }
+      ]
+    },
+    "id": "b7bd",
+    "label": "device"
+  },
+  "message": "device created"
+}
+```
+
+Notice how the resulting device is structured: it has a list of related templates (`template` attribute) and each of its attributes are separated by template ID: `temperature`, `pressure` and `model` are inside attribute `1` (ID of the first created template) and `gps` is inside attribute `2` (ID of the second template). The new device ID can be found in the `id` attribute, which is `b7bd`.
+
+A few considerations must be made:
+
+- If the templates used to compose this new device had attributes with the same name, an error would be generated and the device would not be created.
+- If any of the related templates are removed, all its attributes will also be removed from the devices that were created using it. So be careful.
+
+Let's retrieve this new device:
+
+```bash
+curl -X GET http://localhost:8000/device -H "Authorization: Bearer ${JWT}"
+```
+
+This request will list all created devices for the user.
+
+```json
+{
+  "pagination": {
+    "has_next": false,
+    "next_page": null,
+    "total": 1,
+    "page": 1
+  },
+  "devices": [
+    {
+      "templates": [
+        1,
+        2
+      ],
+      "created": "2018-01-05T17:33:31.605748+00:00",
+      "attrs": {
+        "1": [
+          {
+            "template_id": "1",
+            "created": "2018-01-05T15:41:54.840116+00:00",
+            "label": "temperature",
+            "value_type": "float",
+            "type": "dynamic",
+            "id": 1
+          },
+          {
+            "template_id": "1",
+            "created": "2018-01-05T15:41:54.882169+00:00",
+            "label": "pressure",
+            "value_type": "float",
+            "type": "dynamic",
+            "id": 2
+          },
+          {
+            "static_value": "SuperTemplate Rev01",
+            "created": "2018-01-05T15:41:54.883507+00:00",
+            "label": "model",
+            "value_type": "string",
+            "type": "static",
+            "id": 3,
+            "template_id": "1"
+          }
+        ],
+        "2": [
+          {
+            "template_id": "2",
+            "created": "2018-01-05T15:47:02.995541+00:00",
+            "label": "gps",
+            "value_type": "geo",
+            "type": "dynamic",
+            "id": 4
+          }
+        ]
+      },
+      "id": "b7bd",
+      "label": "device"
+    }
+  ]
+}
+```
+
+## Removing templates and devices
+
+Removing templates and devices is also very simple. Let's remove the device created previously:
+
+```bash
+curl -X DELETE http://localhost:8000/device/b7bd -H "Authorization: Bearer ${JWT}" 
+```
+
+```json
+{
+  "removed_device": {
+    "templates": [
+      1,
+      2
+    ],
+    "created": "2018-01-05T17:33:31.605748+00:00",
+    "attrs": {
+      "1": [
+        {
+          "template_id": "1",
+          "created": "2018-01-05T15:41:54.840116+00:00",
+          "label": "temperature",
+          "value_type": "float",
+          "type": "dynamic",
+          "id": 1
+        },
+        {
+          "template_id": "1",
+          "created": "2018-01-05T15:41:54.882169+00:00",
+          "label": "pressure",
+          "value_type": "float",
+          "type": "dynamic",
+          "id": 2
+        },
+        {
+          "static_value": "SuperTemplate Rev01",
+          "created": "2018-01-05T15:41:54.883507+00:00",
+          "label": "model",
+          "value_type": "string",
+          "type": "static",
+          "id": 3,
+          "template_id": "1"
+        }
+      ],
+      "2": [
+        {
+          "template_id": "2",
+          "created": "2018-01-05T15:47:02.995541+00:00",
+          "label": "gps",
+          "value_type": "geo",
+          "type": "dynamic",
+          "id": 4
+        }
+      ]
+    },
+    "id": "b7bd",
+    "label": "device"
+  },
+  "result": "ok"
+}
+```
+
+Removing templates is also simple:
+
+```bash
+curl -X DELETE http://localhost:8000/template/1 -H "Authorization: Bearer ${JWT}"
+```
+
+```json
+{
+  "removed": {
+    "created": "2018-01-05T15:41:54.803052+00:00",
+    "attrs": [
+      {
+        "template_id": "1",
+        "created": "2018-01-05T15:41:54.840116+00:00",
+        "label": "temperature",
+        "value_type": "float",
+        "type": "dynamic",
+        "id": 1
+      },
+      {
+        "template_id": "1",
+        "created": "2018-01-05T15:41:54.882169+00:00",
+        "label": "pressure",
+        "value_type": "float",
+        "type": "dynamic",
+        "id": 2
+      },
+      {
+        "static_value": "SuperTemplate Rev01",
+        "created": "2018-01-05T15:41:54.883507+00:00",
+        "label": "model",
+        "value_type": "string",
+        "type": "static",
+        "id": 3,
+        "template_id": "1"
+      }
+    ],
+    "id": 1,
+    "label": "SuperTemplate"
+  },
+  "result": "ok"
+}
+```
+
+These are the very basic operations performed by DeviceManager. All operations can be found in [API documentation](https://dojot.github.io/device-manager/apis.html).

--- a/docs/using-device-manager.md
+++ b/docs/using-device-manager.md
@@ -23,7 +23,7 @@ curl -X POST http://localhost:8000/auth \
 
 This token will be stored in ```bash ${JWT}``` bash variable, referenced in all requests.
 
-*IMPORTANT*: Every request made with this token will be valid only for the user associated with this token. For instance, listing created devices will return only those devices which were created by this user.
+*IMPORTANT*: Every request made with this token will be valid only for the tenant (user "service") associated with this token. For instance, listing created devices will return only those devices which were created using this tenant.
 
 -------------
 
@@ -56,7 +56,7 @@ curl -X POST http://localhost:8000/template \
 }'
 ```
 
-Supported value types are: "float", "string", "geo" (for georeference data)s, "integer". Supported value types are: "dynamic" and "static" (static attribute values defined here will be copied to all associated devices)
+Supported `type` values are "dynamic", "static" and "meta". Supported `value_types` are "float", "geo" (for georeferenced data), "string", "integer".
 
 The answer is:
 
@@ -290,7 +290,7 @@ Let's retrieve this new device:
 curl -X GET http://localhost:8000/device -H "Authorization: Bearer ${JWT}"
 ```
 
-This request will list all created devices for the user.
+This request will list all created devices for the tenant.
 
 ```json
 {


### PR DESCRIPTION
This PR adds a new page 'How to use'. It better explains how to use DeviceManager (including token generation and usage). 

This new page could be referenced by the documentation hosted at readthedocs. 

 This is part of dojot/dojot#143