### PR TITLE
Fixes bogus trailing counter, automatic template on delete cascade

### DIFF
--- a/DeviceManager/DatabaseModels.py
+++ b/DeviceManager/DatabaseModels.py
@@ -38,7 +38,8 @@ class DeviceTemplate(db.Model):
     updated = db.Column(db.DateTime, onupdate=datetime.now)
 
     attrs = db.relationship("DeviceAttr", back_populates="template", lazy='joined', cascade="delete")
-    devices = db.relationship("Device", secondary='device_template', back_populates="templates")
+    devices = db.relationship("Device", secondary='device_template', 
+                              back_populates="templates", passive_deletes='all')
 
     config_attrs = db.relationship('DeviceAttr',
                              primaryjoin=db.and_(DeviceAttr.template_id == id,
@@ -70,8 +71,10 @@ class Device(db.Model):
 
 class DeviceTemplateMap(db.Model):
     __tablename__ = 'device_template'
-    device_id = db.Column(db.String(4), db.ForeignKey('devices.id'), primary_key=True, index=True)
-    template_id = db.Column(db.Integer, db.ForeignKey('templates.id'), primary_key=True, index=True)
+    device_id = db.Column(db.String(4), db.ForeignKey('devices.id'),
+                          primary_key=True, index=True)
+    template_id = db.Column(db.Integer, db.ForeignKey('templates.id'),
+                            primary_key=True, index=True, nullable=False)
 
 
 def assert_device_exists(device_id):

--- a/DeviceManager/DeviceManager.py
+++ b/DeviceManager/DeviceManager.py
@@ -115,7 +115,7 @@ def create_device():
             if count == 1:
                 return base
             else:
-                return base + "_%0*d" % (clength, index)
+                return "{}_{:0{width}d}".format(base, index, width=clength)
 
         devices = []
         for i in range(0, count):

--- a/DeviceManager/DeviceManager.py
+++ b/DeviceManager/DeviceManager.py
@@ -115,7 +115,7 @@ def create_device():
             if count == 1:
                 return base
             else:
-                return base + "_%0*d" % (clength, i)
+                return base + "_%0*d" % (clength, index)
 
         devices = []
         for i in range(0, count):

--- a/DeviceManager/DeviceManager.py
+++ b/DeviceManager/DeviceManager.py
@@ -110,11 +110,18 @@ def create_device():
             LOGGER.error(e)
             raise HTTPRequestError(400, "If provided, count must be integer")
 
+
+        def indexed_label(base, index):
+            if count == 1:
+                return base
+            else:
+                return base + "_%0*d" % (clength, i)
+
         devices = []
         for i in range(0, count):
             device_data, json_payload = parse_payload(request, device_schema)
             device_data['id'] = generate_device_id()
-            device_data['label'] = device_data['label'] + "_%0*d" % (clength, i)
+            device_data['label'] = indexed_label(device_data['label'], i)
             device_data.pop('templates', None)  # handled separately by parse_template_list
             orm_device = Device(**device_data)
             parse_template_list(json_payload.get('templates', []), orm_device)

--- a/DeviceManager/TemplateManager.py
+++ b/DeviceManager/TemplateManager.py
@@ -102,8 +102,11 @@ def remove_template(templateid):
         tpl = assert_template_exists(templateid)
 
         json_template = template_schema.dump(tpl).data
-        db.session.delete(tpl)
-        db.session.commit()
+        try:
+            db.session.delete(tpl)
+            db.session.commit()
+        except IntegrityError:
+            raise HTTPRequestError(400, "Template cannot be removed as it is being used by devices")
 
         results = json.dumps({'result': 'ok', 'removed': json_template})
         return make_response(results, 200)


### PR DESCRIPTION
This commit fixes two issues found during the tests of 0.2.0-nightly20180119 build.

First, it removes the bogus counter being added when a single device creation request is performed.

Also, this changes relation configuration between devices and templates to prevent the automatic removal of templates from devices, when a template is removed.