### PR TITLE
Fix for geo:point attributes

### DIFF
--- a/DeviceManager/BackendHandler.py
+++ b/DeviceManager/BackendHandler.py
@@ -82,6 +82,8 @@ class OrionHandler(BackendHandler):
         for tpl in device['attrs']:
             for attr in device['attrs'][tpl]:
                 body[attr['label']] = {"type": attr['value_type']}
+                if (attr['value_type'] == 'geo:point'):
+                    body[attr['label']]['value'] = '0,0'
 
         return body
 


### PR DESCRIPTION
Apparently, Orion doesn't like empty geo:point attributes in v2. It
gives back a 'InvalidRequest' error. This commit adds a dummy 0,0 value
to all properties of type geo:point.