### PR TITLE
Fixing device update request

### DIFF
--- a/DeviceManager/BackendHandler.py
+++ b/DeviceManager/BackendHandler.py
@@ -87,8 +87,8 @@ class OrionHandler(BackendHandler):
 
         return body
 
-    def create_update_device(self, device, is_update=True):
-        target_url = "%s/%s/attrs?type=device" % (self.baseUrl, device['id'])
+    def create_update_device(self, device, type_descr, is_update=True):
+        target_url = "%s/%s/attrs?type=%s&options=keyValues" % (self.baseUrl, device['id'], type_descr)
         body = json.dumps(OrionHandler.parse_device(device, not is_update))
         if not is_update:
             target_url = self.baseUrl
@@ -108,16 +108,16 @@ class OrionHandler(BackendHandler):
         except requests.ConnectionError:
             raise HTTPRequestError(500, "Broker is not reachable")
 
-    def create(self, device):
-        self.create_update_device(device, False)
+    def create(self, device, type_descr):
+        self.create_update_device(device, type_descr, False)
 
     def remove(self, device_id):
         # removal is ignored, thus leaving removed device data lingering in the system
         # (this allows easier recovery/rollback of data by the user)
         pass
 
-    def update(self, device):
-        self.create_update_device(device)
+    def update(self, device, type_descr):
+        self.create_update_device(device, type_descr)
 
 
 class KafkaHandler:


### PR DESCRIPTION
This commit fixes a situation where device updates (using PUT to /device/efac, for instance), would not execute correctly.

The device type was added to a few functions so that updates are performed to the correct device.