### PR TITLE
Updating to the latest version of Marshmallow API

### DIFF
--- a/DeviceManager/DeviceManager.py
+++ b/DeviceManager/DeviceManager.py
@@ -27,10 +27,10 @@ LOGGER.setLevel(logging.INFO)
 
 
 def serialize_full_device(orm_device):
-    data = device_schema.dump(orm_device).data
+    data = device_schema.dump(orm_device)
     data['attrs'] = {}
     for template in orm_device.templates:
-        data['attrs'][template.id] = attr_list_schema.dump(template.attrs).data
+        data['attrs'][template.id] = attr_list_schema.dump(template.attrs)
     return data
 
 


### PR DESCRIPTION
There were some changes in the latest marshmallow's API (in particular the [Schema.load](https://marshmallow.readthedocs.io/en/latest/api_reference.html#marshmallow.Schema.load) function, which does not return a tuple anymore, and the returned structure doesn't have a .data attribute anymore). This PR updates that.