### PR TITLE
Implements attr metadata (attrs of attrs)

### DIFF
--- a/DeviceManager/DatabaseModels.py
+++ b/DeviceManager/DatabaseModels.py
@@ -11,7 +11,6 @@ app.config['SQLALCHEMY_DATABASE_URI'] = CONFIG.get_db_url()
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
-
 class DeviceAttr(db.Model):
     __tablename__ = 'attrs'
 
@@ -126,6 +125,4 @@ def assert_device_relation_exists(device_id, template_id):
 
 
 def handle_consistency_exception(error):
-    # message = error.message.replace('\n','')
-    message = re.sub(r"(^\(.*?\))|\n", "", error.message)
-    raise HTTPRequestError(400, message)
+    raise HTTPRequestError(400, error.orig.diag.message_primary)

--- a/DeviceManager/DatabaseModels.py
+++ b/DeviceManager/DatabaseModels.py
@@ -24,12 +24,18 @@ class DeviceAttr(db.Model):
     value_type = db.Column(db.String(32), nullable=False)
     static_value = db.Column(db.String(128))
 
-    template_id = db.Column(db.Integer, db.ForeignKey('templates.id'), nullable=False)
+    template_id = db.Column(db.Integer, db.ForeignKey('templates.id'))
     template = db.relationship("DeviceTemplate", back_populates="attrs")
+
+    parent_id = db.Column(db.Integer, db.ForeignKey('attrs.id'))
+    parent = db.relationship("DeviceAttr", remote_side=[id])
+    children = db.relationship("DeviceAttr", back_populates="parent", cascade="delete")
 
     # Any given template must not possess two attributes with the same type, label
     __table_args__ = (
         sqlalchemy.UniqueConstraint('template_id', 'type', 'label'),
+        sqlalchemy.CheckConstraint("((template_id IS NULL) AND NOT (parent_id IS NULL)) OR \
+                                     (NOT (template_id IS NULL) AND (parent_id IS NULL))")
     )
 
     def __repr__(self):

--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -351,6 +351,9 @@ class DeviceHandler(object):
             'templates', []), updated_orm_device)
         updated_orm_device.id = device_id
 
+        db.session.delete(old_orm_device)
+        db.session.add(updated_orm_device)
+
         full_device = serialize_full_device(updated_orm_device)
 
         if CONFIG.orion:
@@ -370,9 +373,6 @@ class DeviceHandler(object):
 
         kafka_handler = KafkaHandler()
         kafka_handler.update(full_device, meta={"service": tenant})
-
-        db.session.delete(old_orm_device)
-        db.session.add(updated_orm_device)
 
         try:
             db.session.commit()

--- a/DeviceManager/SerializationModels.py
+++ b/DeviceManager/SerializationModels.py
@@ -12,7 +12,7 @@ class MetaSchema(Schema):
     updated = fields.DateTime(dump_only=True)
     type = fields.Str(required=True)
     value_type = fields.Str(required=True)
-    static_value = fields.Str()
+    static_value = fields.Field()
 
 class AttrSchema(Schema):
     id = fields.Int()
@@ -21,8 +21,8 @@ class AttrSchema(Schema):
     updated = fields.DateTime(dump_only=True)
     type = fields.Str(required=True)
     value_type = fields.Str(required=True)
-    static_value = fields.Str()
-    template_id = fields.Str()
+    static_value = fields.Field()
+    template_id = fields.Str(dump_only=True)
 
     metadata = fields.Nested(MetaSchema, many=True, attribute='children')
 
@@ -30,10 +30,8 @@ class AttrSchema(Schema):
     def remove_null_values(self, data):
         return {key: value for key, value in data.items() if value is not None}
 
-
 attr_schema = AttrSchema()
 attr_list_schema = AttrSchema(many=True)
-
 
 class TemplateSchema(Schema):
     id = fields.Int()
@@ -48,10 +46,8 @@ class TemplateSchema(Schema):
     def remove_null_values(self, data):
         return {key: value for key, value in data.items() if value is not None}
 
-
 template_schema = TemplateSchema()
 template_list_schema = TemplateSchema(many=True)
-
 
 class DeviceSchema(Schema):
     id = fields.String(dump_only=True)
@@ -67,10 +63,8 @@ class DeviceSchema(Schema):
     def remove_null_values(self, data):
         return {key: value for key, value in data.items() if value is not None}
 
-
 device_schema = DeviceSchema()
 device_list_schema = DeviceSchema(many=True)
-
 
 def parse_payload(request, schema):
     try:
@@ -85,7 +79,6 @@ def parse_payload(request, schema):
         results = {'message': 'failed to parse input', 'errors': errors}
         raise HTTPRequestError(400, results)
     return data, json_payload
-
 
 def load_attrs(attr_list, parent_template, base_type, db):
     """

--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -183,6 +183,7 @@ class TemplateHandler:
 
         for attr in old.attrs:
             db.session.delete(attr)
+        db.session.flush()
         for attr in json_payload['attrs']:
             mapped = DeviceAttr(template=old, **attr)
             db.session.add(mapped)

--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -22,11 +22,20 @@ template = Blueprint('template', __name__)
 def attr_format(req, result):
     """ formats output attr list acording to user input """
     attrs_format = req.args.get('attr_format', 'both')
+
+    def remove(d,k):
+        try:
+            LOGGER.info('will remove {}'.format(k))
+            d.pop(k)
+        except KeyError:
+            pass
+
     if attrs_format == 'split':
-        del result['attrs']
+        remove(result, 'attrs')
     elif attrs_format == 'single':
-        del result['config_attrs']
-        del result['data_attrs']
+        remove(result, 'config_attrs')
+        remove(result, 'data_attrs')
+
     return result
 
 
@@ -53,7 +62,7 @@ class TemplateHandler:
         page = DeviceTemplate.query.paginate(page=int(page_number),
                                              per_page=int(per_page),
                                              error_out=False)
-        templates = template_list_schema.dump(page.items).data
+        templates = list(map(lambda x: attr_format(req, x), template_list_schema.dump(page.items).data))
         result = {
             'pagination': {
                 'page': page.page,
@@ -64,7 +73,6 @@ class TemplateHandler:
             'templates': templates
         }
 
-        attr_format(req, result)
         return result
 
     @staticmethod
@@ -188,14 +196,14 @@ class TemplateHandler:
         affected = db.session.query(DeviceTemplateMap) \
                              .filter(DeviceTemplateMap.template_id==template_id) \
                              .all()
-        
+
         affected_devices = []
         for device in affected:
             affected_devices.append(device.device_id)
 
         event = {
-            "event": DeviceEvent.TEMPLATE, 
-            "affected": affected_devices, 
+            "event": DeviceEvent.TEMPLATE,
+            "affected": affected_devices,
             "template": template_schema.dump(old).data,
             "meta": {"service": service}
         }


### PR DESCRIPTION
While this *may* pass travis' dredd tests, I think the apib still needs some updating.

This should allow users to better model a device's attributes, by annotating them with extra metadata, that may be relevant for either an iotagent or an application.

To create a template with attribute metadata:
```bash
(curl -sS -H "${token}" "${target}/template" -H "content-type: application/json" -d @- | python -m json.tool ) <<EOF
{
  "attrs": [
    {
      "label": "temperature",
      "static_value": "",
      "template_id": "1",
      "type": "dynamic",
      "value_type": "float",
      "metadata": [
        { "label": "oi", "static_value": "/0/1/2", "type": "lwm2m", "value_type": "string" },
        { "label": "oid", "static_value": "1.15.155.3", "type": "snmp", "value_type": "string" },
        { "label": "accuracy", "static_value": 0.5, "type": "meta", "value_type": "float" },
        { "label": "unit", "static_value": "celsius", "type": "meta", "value_type": "string" }
      ]
    }
  ],
  "label": "Thermometer"
}
EOF
```