### PR TITLE
Pushing force to gh-pages

### DIFF
--- a/travis/deploy-gh-pages.sh
+++ b/travis/deploy-gh-pages.sh
@@ -2,7 +2,8 @@ git remote add -t gh-pages -f origin-gh-pages https://github.com/${TRAVIS_REPO_S
 git fetch origin-gh-pages
 git checkout gh-pages
 git checkout ${TRAVIS_BRANCH} -- ./docs
-mv docs/* . 
+rm -fr ./_static
+mv docs/* . -f
 git rm -r docs
 
 if [ "${TRAVIS_BRANCH}" == "master" ]
@@ -14,8 +15,8 @@ fi
 node_modules/.bin/aglio -i apiary.apib -o apiary_${VERSION}.html
 
 git add apiary_${VERSION}.html
-git commit -m 'Updating gh-pages'
-git push http://${GITHUB_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG} gh-pages
+git commit -m 'Updating gh-pages' --amend
+git push --force http://${GITHUB_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG} gh-pages
 git checkout -- .
 git clean -fd
 git checkout ${TRAVIS_BRANCH}


### PR DESCRIPTION
This PR changes gh-pages deployment to use push force, instead of a simple commit. 

Also, Travis script was updated to remove _static folder before moving files to the root directory. Therefore all files are properly moved, and the apiary render is updated as expected.