### PR TITLE
Fixes update procedure for templates

### DIFF
--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -367,11 +367,6 @@ class DeviceHandler(object):
         """
         device_data, json_payload = parse_payload(req, device_schema)
 
-        # update sanity check
-        # if 'attrs' in json_payload:
-        #     LOGGER.warn('Got request with "attrs" field set. Ignoring.')
-        #     json_payload.pop('attrs')
-
         tenant = init_tenant_context(req, db)
         old_orm_device = assert_device_exists(device_id)
         db.session.delete(old_orm_device)


### PR DESCRIPTION
This updates how deviceManager uses sqlAlchemy entities, to avoid having an attribute instance be recreated as opposed to be updated.

This also fixes an issue where overridden attribute values would be lost on template updates. 