### PR TITLE
Fixes tenancy context switches

### DIFF
--- a/DeviceManager/DatabaseHandler.py
+++ b/DeviceManager/DatabaseHandler.py
@@ -1,0 +1,35 @@
+from flask import g, request
+from flask_sqlalchemy import SQLAlchemy
+
+from .app import app
+from .conf import CONFIG
+from .utils import get_allowed_service
+
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SQLALCHEMY_DATABASE_URI'] = CONFIG.get_db_url()
+app.config['SQLALCHEMY_BINDS'] = {'__status_monitor__': CONFIG.get_db_url()}
+
+# adapted from https://gist.github.com/miikka/28a7bd77574a00fcec8d
+class MultiTenantSQLAlchemy(SQLAlchemy):
+    def choose_tenant(self, bind_key):
+        if hasattr(g, 'tenant'):
+            raise RuntimeError('Switching tenant in the middle of the request.')
+        g.tenant = bind_key
+
+    def get_engine(self, app=None, bind=None):
+        if bind is None:
+            if not hasattr(g, 'tenant'):
+                raise RuntimeError('No tenant chosen.')
+            bind = g.tenant
+        return super().get_engine(app=app, bind=bind)
+
+db = MultiTenantSQLAlchemy(app)
+
+@app.before_request
+def before_request():
+    tenant = get_allowed_service(request.headers['authorization'])
+    binds = app.config.get('SQLALCHEMY_BINDS')
+    if binds.get(tenant, None) is None:
+        binds[tenant] = CONFIG.get_db_url()
+        app.config['SQLALCHEMY_BINDS'] = binds
+    db.choose_tenant(tenant)

--- a/DeviceManager/DatabaseModels.py
+++ b/DeviceManager/DatabaseModels.py
@@ -1,16 +1,12 @@
 from datetime import datetime
 import re
 import sqlalchemy
-from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import event
 
-from DeviceManager.app import app
-from DeviceManager.utils import HTTPRequestError
-from DeviceManager.conf import CONFIG
-
-app.config['SQLALCHEMY_DATABASE_URI'] = CONFIG.get_db_url()
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db = SQLAlchemy(app)
+from .app import app
+from .utils import HTTPRequestError
+from .conf import CONFIG
+from .DatabaseHandler import db
 
 class DeviceOverride(db.Model):
     __tablename__ = 'overrides'

--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -17,7 +17,8 @@ from DeviceManager.utils import HTTPRequestError
 from DeviceManager.conf import CONFIG
 from DeviceManager.BackendHandler import OrionHandler, KafkaHandler, PersistenceHandler
 
-from DeviceManager.DatabaseModels import db, assert_device_exists, assert_template_exists
+from DeviceManager.DatabaseHandler import db
+from DeviceManager.DatabaseModels import assert_device_exists, assert_template_exists
 from DeviceManager.DatabaseModels import handle_consistency_exception, assert_device_relation_exists
 from DeviceManager.DatabaseModels import DeviceTemplate, DeviceAttr, Device, DeviceTemplateMap, DeviceAttrsPsk
 from DeviceManager.DatabaseModels import DeviceOverride
@@ -613,7 +614,7 @@ class DeviceHandler(object):
         # todo remove this magic number
         if key_length > 1024 or key_length <= 0:
             raise HTTPRequestError(400, "key_length must be greater than 0 and lesser than {}".format(1024))
-        
+
         is_all_psk_attr_valid = False
         target_attrs_data = []
 
@@ -629,7 +630,7 @@ class DeviceHandler(object):
             if not is_all_psk_attr_valid:
                 raise HTTPRequestError(400, "Not found some attributes, "
                     "please check them")
-                    
+
             if len(target_attributes) != len(target_attrs_data):
                 if not is_all_psk_attr_valid:
                     raise HTTPRequestError(400,
@@ -665,7 +666,7 @@ class DeviceHandler(object):
                 psk_entry.psk = encrypted_psk
 
             result.append( {'attribute': attr["label"], 'psk': psk_hex} )
-        
+
         device_orm.updated = datetime.now()
         db.session.commit()
 

--- a/DeviceManager/SerializationModels.py
+++ b/DeviceManager/SerializationModels.py
@@ -17,7 +17,6 @@ class MetaSchema(Schema):
 
 def validate_attr_label(input):
     if re.match(r'^[a-zA-Z0-9_-]+$', input) is None:
-        print('validation for {} failed'.format(input))
         raise ValidationError("Labels must contain letters, numbers or dashes(-_)")
     return '-- invalid --'
 

--- a/DeviceManager/StatusMonitor.py
+++ b/DeviceManager/StatusMonitor.py
@@ -8,7 +8,8 @@ import redis
 
 from .conf import CONFIG
 from .KafkaNotifier import get_topic
-from .DatabaseModels import db, Device
+from .DatabaseModels import Device
+from .DatabaseHandler import db
 
 import threading
 

--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -2,7 +2,7 @@ import logging
 from flask import Blueprint, request, jsonify, make_response
 from sqlalchemy.exc import IntegrityError
 
-from DeviceManager.DatabaseModels import db
+from DeviceManager.DatabaseHandler import db
 from DeviceManager.DatabaseModels import handle_consistency_exception, assert_template_exists
 from DeviceManager.DatabaseModels import DeviceTemplate, DeviceAttr, DeviceTemplateMap
 from DeviceManager.SerializationModels import template_list_schema, template_schema

--- a/DeviceManager/main.py
+++ b/DeviceManager/main.py
@@ -1,3 +1,4 @@
+from flask import g
 from flask_migrate import Migrate
 
 from DeviceManager.app import app
@@ -7,12 +8,14 @@ import DeviceManager.DeviceHandler
 import DeviceManager.TemplateHandler
 import DeviceManager.ErrorManager
 
-from .DatabaseModels import db
+from .DatabaseHandler import db
 from .StatusMonitor import StatusMonitor
 from .TenancyManager import list_tenants
 
-for tenant in list_tenants(db.session):
-    StatusMonitor(tenant)
+with app.app_context():
+    g.tenant = '__status_monitor__'
+    for tenant in list_tenants(db.session):
+        StatusMonitor(tenant)
 
 migrate = Migrate(app, db)
 

--- a/DeviceManager/utils.py
+++ b/DeviceManager/utils.py
@@ -62,6 +62,25 @@ def decode_base64(data):
         data += '=' * (4 - missing_padding)
     return base64.decodebytes(data.encode()).decode()
 
+def get_allowed_service(token):
+    """
+        Parses the authorization token, returning the service to be used when
+        configuring the FIWARE backend
+
+        :param token: JWT token to be parsed
+        :returns: Fiware-service to be used on API calls
+        :raises ValueError: for invalid token received
+    """
+    if not token or len(token) == 0:
+        raise ValueError("Invalid authentication token")
+
+    payload = token.split('.')[1]
+    try:
+        data = json.loads(decode_base64(payload))
+        return data['service']
+    except Exception as ex:
+        raise ValueError("Invalid authentication token payload - not json object", ex)
+
 def encrypt(plain_text):
     # plain_text is padded so its length is multiple of cipher block size
     plain_text_pad = pad(plain_text)


### PR DESCRIPTION
This fixes an issue where sessions end up being used by two different tenants, causing schema initialization to fail.

This solves that by using SQLAlchemy's bind structure to allow tenancy context to be managed at the engine level. Since calls from a particular tenant always share a same engine, all sessions that derive from it are, correctly, set to work on the same schema, fixing the bug by construction.