### PR TITLE
Improves overrides' sanity checks

### DIFF
--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -81,7 +81,11 @@ def auto_create_template(json_payload, new_device):
             if orm_template is None:
                 raise HTTPRequestError(400, 'Unknown template "{}" in attr list'.format(orm_template))
 
-            target = int(attr['id'])
+            try:
+                target = int(attr['id'])
+            except ValueError:
+                raise HTTPRequestError(400, "Unkown attribute \"{}\" in override list".format(target))
+
             found = False
             for orm_attr in orm_template.attrs:
                 if target == orm_attr.id:

--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -195,13 +195,13 @@ class DeviceHandler(object):
 
         target_label = req.args.get('label', None)
         if target_label:
-            parsed_query.append("devices.label = '{}'".format(target_label))
+            parsed_query.append("devices.label like '%{}%'".format(target_label))
 
         if len(parsed_query):
             page = db.session.query(Device) \
-                             .join(DeviceTemplateMap) \
+                             .join(DeviceTemplateMap, isouter=True) \
                              .join(DeviceTemplate) \
-                             .join(DeviceAttr) \
+                             .join(DeviceAttr, isouter=True) \
                              .filter(*parsed_query) \
                              .paginate(**pagination)
         else:

--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -197,7 +197,7 @@ class DeviceHandler(object):
         if target_label:
             parsed_query.append("devices.label like '%{}%'".format(target_label))
 
-        if len(parsed_query):
+        if parsed_query:
             page = db.session.query(Device) \
                              .join(DeviceTemplateMap, isouter=True) \
                              .join(DeviceTemplate) \

--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -84,7 +84,7 @@ def auto_create_template(json_payload, new_device):
             try:
                 target = int(attr['id'])
             except ValueError:
-                raise HTTPRequestError(400, "Unkown attribute \"{}\" in override list".format(target))
+                raise HTTPRequestError(400, "Unkown attribute \"{}\" in override list".format(attr['id']))
 
             found = False
             for orm_attr in orm_template.attrs:

--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -77,7 +77,7 @@ class TemplateHandler:
         if target_label:
             parsed_query.append(text("templates.label like '%{}%'".format(target_label)))
 
-        if len(parsed_query):
+        if parsed_query:
             page = db.session.query(DeviceTemplate) \
                              .join(DeviceAttr, isouter=True) \
                              .filter(*parsed_query) \

--- a/docs/apiary.apib
+++ b/docs/apiary.apib
@@ -111,17 +111,20 @@ Register a new template
             }
 
 
-### Get the current list of templates [GET /template{?page_size,page_num,attr_format}]
+### Get the current list of templates [GET /template{?page_size,page_num,attr_format,attr,label}]
 Get the full list of templates with all their associated attributes.
 
 + Parameters
     + page_size: 20 (integer, optional)
     + page_num: 1 (integer, optional)
-    + attr_format: "both" (string, optional)
+    + attr_format: both (string, optional)
 
         Must be one of "both", "single" (if 'data_attrs' and 'config_attrs' are to be omited)
         or "split" (if 'attrs' list is to be omited). 'attrs' field will always contain all
         template attributes that are listed by both 'data_attrs' and 'config_attrs'.
+
+    + attr: foo=bar (string, optional) - Return only templates that posess a given attribute's value
+    + label: dummy (string, optional) - Return only templates that are named accordingly (prefix or suffix match)
 
 + Request
     + Headers
@@ -566,7 +569,7 @@ Retrieves all information from a specific device
             }
 
 
-### Get the current list of devices [GET /device{?page_size,page_num,idsOnly}]
+### Get the current list of devices [GET /device{?page_size,page_num,idsOnly,label,attr}]
 Get the full list of devices with all their associated attributes.
 Each attribute from *attrs* is the template ID from where the attributes came from.
 In this example, there is only one template (ID 1).
@@ -574,6 +577,8 @@ In this example, there is only one template (ID 1).
     + page_size: 20 (integer, optional)
     + page_num: 1 (integer, optional)
     + idsOnly: false (booelan, optional) - Return only the ids of all existing devices. Ignores any `page_size` and `page_num` configurations
+    + attr: foo=bar (string, optional) - Return only devices that posess a given attribute's value
+    + label: dummy (string, optional) - Return only devices that are named accordingly (prefix or suffix match)
 
 + Request
       + Headers
@@ -865,11 +870,11 @@ Removes a device
                 "message": "No such device: aaaa",
                 "status": 404
             }
-            
+
 ### Generate PSK [POST /device/gen_psk/{device_id}{?key_length,attrs}]
 Generates pre shared keys for a specific device.
 
-This endpoint generates a random key to attributes with the 'type_value' equal 
+This endpoint generates a random key to attributes with the 'type_value' equal
 to 'psk'. The generated key is returned just once, i.e, the user can not retrive
 it via /device.
 
@@ -878,25 +883,25 @@ Calling this endpoint twice with the same target attributes will override the pr
 + Parameters
     + device_id: efac (string, required) - Device id
     + key_length: 8 (integer, required) - Key's length in bytes
-    + attrs: shared_key (string, optional) - Comma separated list with the 
-    target attributes. If this parameter is not present the all aplicable 
+    + attrs: shared_key (string, optional) - Comma separated list with the
+    target attributes. If this parameter is not present the all aplicable
     attributes will be the target.
 
 + Request
 
     + Headers
-    
+
             Authorization: Bearer JWT
 
 + Response 200 (application/json)
 
     + Body
-    
+
             [
                 {
                     "attribute": "shared_key",
                     "psk": "9ee5c4eeca90b431"
-                }                  
+                }
             ]
 
 + Response 204 (application/json)
@@ -930,7 +935,7 @@ Calling this endpoint twice with the same target attributes will override the pr
         {
             "message": "Some attribute is not a 'psk' type_value"
         }
-        
+
 # Group Internal
 Internal endpoins must not be expose outside the platform. They are used to
 internal communcation with other services.
@@ -944,7 +949,7 @@ Retrieves all information from a specific device.
 
 + Parameters
     + device_id: efac (string, required) - Device id
-    
+
 + Request
     + Headers
 

--- a/tests/dredd-hooks/operation_hook.py
+++ b/tests/dredd-hooks/operation_hook.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import dredd_hooks as hooks
 import json
+import re
 
 # This shouldn't be needed
 from werkzeug.datastructures import MultiDict
@@ -56,6 +57,19 @@ def create_sample_template():
 
     result = TemplateHandler.create_template(Request(req))
     template_id = result['template']['id']
+
+
+@hooks.before('Templates > Templates > Get the current list of templates')
+@hooks.before('Devices > Device info > Get the current list of devices > Example 1')
+@hooks.before('Devices > Device info > Get the current list of devices > Example 2')
+def remove_filters(transaction):
+    print('will run hook {}'.format(transaction['name']))
+    original = transaction['fullPath']
+    if '?' in original:
+        base = original[:original.index('?')]
+        params = re.findall(r'(?<=[\?&])([\w-]+)=([\w-]+)', original)
+        filtered = list(filter(lambda x: x[0] not in  ['attr', 'label'], params))
+        transaction['fullPath'] = base + '?' + '&'.join(map(lambda x: "{}={}".format(x[0], x[1]), filtered))
 
 
 @hooks.before('Templates > Templates > Get the current list of templates')

--- a/tests/dredd-hooks/operation_hook.py
+++ b/tests/dredd-hooks/operation_hook.py
@@ -63,7 +63,6 @@ def create_sample_template():
 @hooks.before('Devices > Device info > Get the current list of devices > Example 1')
 @hooks.before('Devices > Device info > Get the current list of devices > Example 2')
 def remove_filters(transaction):
-    print('will run hook {}'.format(transaction['name']))
     original = transaction['fullPath']
     if '?' in original:
         base = original[:original.index('?')]


### PR DESCRIPTION
This PR aims to make device-manager a tad smarter when parsing attribute overrides supplied by a user. Mainly, this fixes an elusive bug where sometimes, GUI would send an invalid `attr` stanza on request payload (verified on `POST`) and `device-manager` would fail to process due to an unchecked exception being raised.

Logs for such bug are as follows.

```
[2018-04-24 15:08:33,738] ERROR in app: Exception on /device [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/src/app/DeviceManager/DeviceHandler.py", line 712, in flask_create_device
    result = DeviceHandler.create_device(request)
  File "/usr/src/app/DeviceManager/DeviceHandler.py", line 303, in create_device
    auto_create_template(json_payload, orm_device)
  File "/usr/src/app/DeviceManager/DeviceHandler.py", line 84, in auto_create_template
    target = int(attr['id'])
ValueError: invalid literal for int() with base 10: '925cc240.20ace'
172.18.0.24 - - [24/Apr/2018:15:08:33 +0000] "POST /device HTTP/1.1" 500 30 "http://10.50.11.195:8000/" "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
[2018-04-24 15:08:41,873] ERROR in app: Exception on /device [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/src/app/DeviceManager/DeviceHandler.py", line 712, in flask_create_device
    result = DeviceHandler.create_device(request)
  File "/usr/src/app/DeviceManager/DeviceHandler.py", line 303, in create_device
    auto_create_template(json_payload, orm_device)
  File "/usr/src/app/DeviceManager/DeviceHandler.py", line 84, in auto_create_template
    target = int(attr['id'])
ValueError: invalid literal for int() with base 10: '925cc240.20ace'
172.18.0.24 - - [24/Apr/2018:15:08:41 +0000] "POST /device HTTP/1.1" 500 30 "http://10.50.11.195:8000/" "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
```