### PR TITLE
Fixes parsing of status updates

### DIFF
--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -192,7 +192,7 @@ class DeviceHandler(object):
         pagination = {'page': page_number, 'per_page': per_page, 'error_out': False}
 
         SORT_CRITERION = {
-            'label': func.lower(Device.label),
+            'label': Device.label,
             None: Device.id
         }
         sortBy = SORT_CRITERION.get(req.args.get('sortBy', None), Device.id)

--- a/DeviceManager/StatusMonitor.py
+++ b/DeviceManager/StatusMonitor.py
@@ -181,13 +181,16 @@ class StatusMonitor:
         # print('gc devices {}'.format(devices))
         now = time.time()
         for device in devices:
-            exp = float(self.redis.get(device).decode('utf-8'))
-            # print('will check {} {}'.format(device, exp))
-            if now > exp:
-                self.redis.delete(device)
-                print('device {} offline'.format(device))
-                parsed = device.split(':')
-                self.notify(parsed[1],parsed[2],'offline')
+            try:
+                exp = float(self.redis.get(device).decode('utf-8'))
+                # print('will check {} {}'.format(device, exp))
+                if now > exp:
+                    self.redis.delete(device)
+                    print('device {} offline'.format(device))
+                    parsed = device.split(':')
+                    self.notify(parsed[1],parsed[2],'offline')
+            except Exception as error:
+                print('Failed to process device "{}": {}'.format(device, error))
 
     @staticmethod
     def get_status(tenant, device=None):

--- a/DeviceManager/StatusMonitor.py
+++ b/DeviceManager/StatusMonitor.py
@@ -203,7 +203,10 @@ class StatusMonitor:
             for key in data:
                 if key is not None:
                     device = StatusMonitor.parse_key_from(key.decode('utf-8'))['device']
-                    exp = float(client.get(key).decode('utf-8'))
+                    try:
+                        exp = float(client.get(key).decode('utf-8'))
+                    except AttributeError:
+                        exp = None
                     if (exp is not None) and (timeref < exp):
                         status[device] = 'online'
                     else:

--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -78,7 +78,7 @@ class TemplateHandler:
             parsed_query.append(text("templates.label like '%{}%'".format(target_label)))
 
         SORT_CRITERION = {
-            'label': func.lower(DeviceTemplate.label),
+            'label': DeviceTemplate.label,
             None: DeviceTemplate.id
         }
         sortBy = SORT_CRITERION.get(req.args.get('sortBy', None), DeviceTemplate.id)

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -5,7 +5,7 @@ if [ $TRAVIS_BRANCH != "master" ] ; then
   version=$TRAVIS_BRANCH
 fi
 
-tag=dojot/device-manager:$version
+tag=$TRAVIS_REPO_SLUG:$version
 
 docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
 docker tag dojot/device-manager ${tag}


### PR DESCRIPTION
If between `SCAN` and `GET` a device gets evicted (i.e. times out), the corresponding `GET` would fail, and, since that wasn't being handled, the API call that may have originated the status retrieval would return 500.

This fixes that.