### PR TITLE
fix: fixing setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,12 @@ import os
 import setuptools
 import sys
 
-from pip import download
-from pip import req
+try:
+    from pip import download
+    from pip import req
+except ImportError as e:
+    from pip._internal import download
+    from pip._internal import req
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This PR fixes a tiny bug that appeared with newer versions of pip. Two required modules (namely `download` and `req` are now located in a submodule called `pip_internal`. This is a workaround this issue.

In the future, we might want to look into this again in order to sanitize component installation procedure.


This is child of dojot/dojot#597