### PR TITLE
fix: saving new template with metadata

### DIFF
--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -284,11 +284,17 @@ class TemplateHandler:
             return attrs_from_request
 
         to_be_added = analyze_attrs(old.attrs, new)
-        for a in to_be_added:
-            LOGGER.debug(f" Adding new attribute {a}")
-            if "id" in a:
-                del a["id"]
-            db.session.add(DeviceAttr(template=old, **a))
+        for attr in to_be_added:
+            LOGGER.debug(f" Adding new attribute {attr}")
+            if "id" in attr:
+                del attr["id"]
+            child = DeviceAttr(template=old, **attr)    
+            db.session.add(child)
+            if "metadata" in attr:
+                for metadata in attr["metadata"]:
+                    LOGGER.debug(f" Adding new metadata {metadata}")
+                    orm_child = DeviceAttr(parent=child, **metadata)
+                    db.session.add(orm_child)
         try:
             LOGGER.debug(f" Commiting new data...")
             db.session.commit()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR save all metadata that is sent with a new template.


* **What is the current behavior?** (You can also link to an open issue here)
When a new template is sent, no matadata is persisted.


* **What is the new behavior (if this is a feature change)?**
All metadata is persisted for a new template.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#939

* **Other information**:
