### PR TITLE
fix: allowing null metadata

### DIFF
--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -277,7 +277,7 @@ class TemplateHandler:
                 if not found:
                     LOGGER.debug(f" Removing attribute {attr_from_db.label}")
                     db.session.delete(attr_from_db)
-            if parentAttr:
+            if parentAttr and attrs_from_request is not None:
                 for attr_from_request in attrs_from_request:
                     orm_child = DeviceAttr(parent=parentAttr, **attr_from_request)
                     db.session.add(orm_child)
@@ -290,7 +290,7 @@ class TemplateHandler:
                 del attr["id"]
             child = DeviceAttr(template=old, **attr)    
             db.session.add(child)
-            if "metadata" in attr:
+            if "metadata" in attr and attr["metadata"] is not None:
                 for metadata in attr["metadata"]:
                     LOGGER.debug(f" Adding new metadata {metadata}")
                     orm_child = DeviceAttr(parent=child, **metadata)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR allows to send null value for "metadata" attribute when creating a template


* **What is the current behavior?** (You can also link to an open issue here)
When you create a template with a null metadata, a exception is thrown


* **What is the new behavior (if this is a feature change)?**
When you create a template with a null metadata, the metadata is ignored


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Is connected to dojot/dojot#939

* **Other information**:
