### PR TITLE
fix: changing response data types

### DIFF
--- a/DeviceManager/DatabaseModels.py
+++ b/DeviceManager/DatabaseModels.py
@@ -204,7 +204,7 @@ def transform_get(target, context):
         elif target.value_type == "string":
             # static_value is already a string
             pass
-        elif target.value_type == "boolean":
+        elif (target.value_type == "boolean") or (target.value_type == "bool"):
             target.static_value = bool(target.static_value)
         elif target.value_type == "array" or target.value_type == "object":
             target.static_value = json.loads(target.static_value)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Any static_value is converted to a string when reading information about a template or device.


* **What is the new behavior (if this is a feature change)?**
This commit changes how an attribute type in a response JSON is generated. This will now rely on "value_type" attribute. It follows JSON specification, i.e., valid types are number, string, boolean, array, object and null. Any other types will be rendered as a string.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#1024

* **Other information**:
