### PR TITLE
fix: moving actuator attributes to from config to data set

### DIFF
--- a/DeviceManager/DatabaseModels.py
+++ b/DeviceManager/DatabaseModels.py
@@ -85,10 +85,11 @@ class DeviceTemplate(db.Model):
     config_attrs = db.relationship('DeviceAttr',
                                    primaryjoin=db.and_(DeviceAttr.template_id == id,
                                                        DeviceAttr.type != 'static',
-                                                       DeviceAttr.type != 'dynamic'))
+                                                       DeviceAttr.type != 'dynamic',
+                                                       DeviceAttr.type != 'actuator'))
     data_attrs = db.relationship('DeviceAttr',
                                  primaryjoin=db.and_(DeviceAttr.template_id == id,
-                                                     DeviceAttr.type.in_(('static', 'dynamic'))))
+                                                     DeviceAttr.type.in_(('static', 'dynamic', 'actuator'))))
 
     def __repr__(self):
         return "<Template(label={}, attrs={})>".format(self.label, self.attrs)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
Actuator attributes are listed in 'config_attrs' set.


* **What is the new behavior (if this is a feature change)?**
Actuator attributes are now listed in 'data_attrs' set.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#1018

* **Other information**:
