### PR TITLE
bugfix: fixing template update when there is no attribute label

### DIFF
--- a/DeviceManager/SerializationModels.py
+++ b/DeviceManager/SerializationModels.py
@@ -26,9 +26,12 @@ def set_id_with_import_id(data):
 
 def validate_repeated_attrs(data):
     if ('attrs' in data):
-        uniques = { each['label'] : each for each in data['attrs'] }.values()
-        if len(data['attrs']) > len(uniques):
-            raise ValidationError('a device can not have repeated attributes')
+        try:
+            uniques = { each['label'] : each for each in data['attrs'] }.values()
+            if len(data['attrs']) > len(uniques):
+                raise ValidationError('a device can not have repeated attributes')
+        except KeyError:
+            raise ValidationError('missing label attribute')
 
 class MetaSchema(Schema):
     id = fields.Int(dump_only=True)


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When updating a template, if the user adds more static values, their labels must be also defined. If not, DeviceManager should give a meaningful error message - which is not being done.


* **What is the new behavior (if this is a feature change)?**
The missing parameters are listed in a error message.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#1084

* **Other information**:
