### PR TITLE
Automate documentation build in dockerhub

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -12,4 +12,5 @@ if [ $TRAVIS_PULL_REQUEST == false ] ; then
   echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   docker tag ${TRAVIS_REPO_SLUG} ${tag}
   docker push $tag
+  curl -X POST -H "Content-Type: application/json" --data '{}' ${DOCKER_HUB_BUILD_URL}
 fi


### PR DESCRIPTION
This PR contains the configuration to automate build in docker hub.

- Add in **publish.sh** called in **travis.yml** to call the endpoint of docker hub trigger. Was created a environment variable DOCKER_HUB_BUILD_URL.

- In TravisCI declare this environment variable in settings.

- Configure the docker hub to link with the repository on github in automated build and set the autobuild to false.