### PR TITLE
chore: add preload 

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,6 +39,7 @@ if [ ${command} = 'start' ]; then
         exec gunicorn DeviceManager.main:app \
                   --bind 0.0.0.0:5000 \
                   --reload -R \
+                  --preload \
                   --timeout ${TIMEOUT} \
                   --access-logfile - \
                   --log-file - \


### PR DESCRIPTION
Load application code before the worker processes are forked.

By preloading an application you can save some RAM resources as well as speed up server boot times. Although, if you defer application loading to each worker process, you can reload your application code easily by restarting workers.

-------
Preload helps to show some internal errors. 