### PR TITLE
[0.4.4] - Refresh "updated" column of template every time template structure changes

### DIFF
--- a/DeviceManager/TemplateHandler.py
+++ b/DeviceManager/TemplateHandler.py
@@ -64,6 +64,11 @@ def paginate(query, page, per_page=20, error_out=False):
 
     return Pagination(query, page, per_page, total, items)
 
+def refresh_template_update_column(db, template):
+    if db.session.new or db.session.deleted:
+        LOGGER.debug('The template structure has changed, refreshing "updated" column.')
+        template.updated = datetime.now()
+
 class TemplateHandler:
 
     def __init__(self):
@@ -346,6 +351,7 @@ class TemplateHandler:
                     db.session.add(orm_child)
         try:
             LOGGER.debug(f" Commiting new data...")
+            refresh_template_update_column(db, old)
             db.session.commit()
             LOGGER.debug("... data committed.")
         except IntegrityError as error:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Service improvement


* **What is the current behavior?** (You can also link to an open issue here)
The column "updated" of the template table only is refreshed when the templates table changes, it is done by SQLAlchemy ORM framework (visit the class DeviceTemplate for more details)


* **What is the new behavior (if this is a feature change)?**
The column "updated" of the templates table is refreshed every time itself or its related table attrs changes. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it doesn't

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No, there isn't

* **Other information**:
https://github.com/dojot/dojot/issues/1729