### PR TITLE
correcting error in the readme writing of the word "crypto"

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker-compose -f local/compose.yml -p devm up -d
 # Builds devm container (this may take a while)
 docker build -f Dockerfile -t local/devicemanager .
 # Runs devm manually, using the infra that's been just created
-# Must pass the environment variables of cryto to run
+# Must pass the environment variables of crypto to run
 docker run --rm -it --network devm_default -e DEV_MNGR_CRYPTO_PASS=${CRYPTO_PASS} -e DEV_MNGR_CRYPTO_IV=${CRYPTO_IV} -e DEV_MNGR_CRYPTO_SALT=${CRYPTO_SALT} local/devicemanager
 #
 # Example: docker run --rm -it --network devm_default -e DEV_MNGR_CRYPTO_PASS='kamehameHA'  -e DEV_MNGR_CRYPTO_IV=1234567890123456 -e DEV_MNGR_CRYPTO_SALT='shuriken' local/devicemanager


### PR DESCRIPTION
In the repository readme, there was an error in the spelling of the word "crypto", missing the letter "p". So, this PR is fixing this error in the repository readme.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
[dojot/dojot#1498](https://github.com/dojot/dojot/issues/1498)