### PR TITLE
corrected empty space in return actuation

### DIFF
--- a/DeviceManager/DeviceHandler.py
+++ b/DeviceManager/DeviceHandler.py
@@ -626,7 +626,7 @@ class DeviceHandler(object):
             kafka_handler_instance = cls.kafka.getInstance(cls.kafka.kafkaNotifier)
             kafka_handler_instance.configure(payload, meta)
             LOGGER.debug(f' Configuration sent.')
-            result = {f' status': 'configuration sent to device'}
+            result = {f'status': 'configuration sent to device'}
         else:
             LOGGER.warning(f' invalid attributes detected in command: {invalid_attrs}')
             result = {

--- a/docs/apiary.apib
+++ b/docs/apiary.apib
@@ -1084,7 +1084,7 @@ must be of type `actuator`.
 + Response 200 (application/json)
 
             {
-                " status": "configuration sent to device"
+                "status": "configuration sent to device"
             }
 
 

--- a/tests/test_device_handler.py
+++ b/tests/test_device_handler.py
@@ -323,7 +323,7 @@ class TestDeviceHandler(unittest.TestCase):
                 with patch.object(KafkaInstanceHandler, "getInstance", return_value=MagicMock()):
                     result = DeviceHandler.configure_device(params, 'test_device_id', token)
                     self.assertIsNotNone(result)
-                    self.assertEqual(result[' status'], 'configuration sent to device')
+                    self.assertEqual(result['status'], 'configuration sent to device')
                 
                 data = '{"topic": "/admin/efac/config", "attrs": {"test_attr": "xpto"}}'
                 params = {'data': data}


### PR DESCRIPTION
the empty space that continues in the return of the devices performance has been fixed.
And also in the docs/apiary.apib files there was this same space, and I removed it.
And in the test files "test_device_handler.py" there was also, but I have already removed those spaces mentioned above.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
[dojot/dojot#1814](https://github.com/dojot/dojot/issues/1814)
