### PR TITLE
[DOJOT-229] Fix - Format log timestamp correctly

### DIFF
--- a/DeviceManager/Logger.py
+++ b/DeviceManager/Logger.py
@@ -16,7 +16,7 @@ class Log:
             'disable_existing_loggers': True,
         }
         
-        dateFormat = datetime.now(timezone.utc).astimezone().isoformat("T","milliseconds")
+        dateFormat = '%Y-%m-%dT%H:%M:%SZ'
         config_log.dictConfig(LOGGING)
         self.formatter = ColoredFormatter(LOG_FORMAT, dateFormat)
         self.log = logging.getLogger('device-manager.' + __name__)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

* **What is the current behavior?** (You can also link to an open issue here)
Timestamp nos logs são sempre iguais porque formatava errado

* **What is the new behavior (if this is a feature change)?**
Agora formata corretamente o timestamp

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
https://dojot.atlassian.net/browse/DOJOT-229
https://dojot.atlassian.net/browse/DOJOT-198

* **Other information**:

Não foi possível formatar o timestamp com precisão de nanosegundos porque não exite opção de formatação para isso.

Eis aqui alguns links uteis para comprovar isso:
- Formatação padrão do timestamp, no caso de não customizarmos isso na instância do logger: https://coloredlogs.readthedocs.io/en/latest/api.html#coloredlogs.DEFAULT_DATE_FORMAT
- Tabela com todas as opções de formatação: https://docs.python.org/3/library/time.html#time.strftime

Outro detalhe: **Não adicionei o timezone offset no timestamp (ex: -03:00)**

---

Como ficaram os logs agora:

![image](https://user-images.githubusercontent.com/36794274/208157955-58d4843d-abf8-4551-868d-f8e4147073d1.png)